### PR TITLE
Adds PHP7 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ before_script:
 
 script:
   - phpunit --coverage-clover build/logs/clover.xml
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
 
 notifications:
   irc: "irc.freenode.org#ouarz"
@@ -50,4 +48,6 @@ notifications:
     on_failure: change
 
 after_script:
-- php vendor/bin/coveralls -v
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
+  - php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   #- hhvm
 
 matrix:
@@ -18,7 +19,7 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=pgsql
-  - DB=memcache
+  - DB=memcached
 
 before_script:
   - sh -c "if [ '$DB' = 'apc' -a ! $(echo $TRAVIS_PHP_VERSION|awk -F. '{printf("%d%02d%02d\n",$1,$2,$3,$4);}') -ge 50500 ]; then echo 'extension="apc.so"' >> `php --ini | grep 'Loaded Configuration' | sed -e 's|.*:\s*||'`; else printf "yes\n" | pecl install apcu-beta; fi"
@@ -29,7 +30,7 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS apix_tests;'; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS apix_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE apix_tests;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'memcache' ]; then sudo pecl install memcached-2.0.1; /usr/bin/memcached -d; fi"
+  - sh -c "if [ '$DB' = 'memcached' ]; then sudo pecl install memcached-2.0.1; /usr/bin/memcached -d; fi"
   #- phpenv rehash
   - travis_retry composer self-update
   - travis_retry composer install --dev --no-interaction --prefer-source

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ APIx Cache is a generic and thin cache wrapper with a simple interface to variou
 
 * **PSR-Cache** (proposed) standard is provided thru a factory wrapper class.
 * Unit **tested** and compliant with PSR0, PSR1 and PSR2.
-* Continuously integrated with **PHP 5.3**, **5.4**, **5.5** and **5.6**; and against APC, Redis, MongoDB, Sqlite, MySQL, PgSQL and Memcached...
+* Continuously integrated with **PHP 5.3**, **5.4**, **5.5**, **5.6** and **7**; and against APC, Redis, MongoDB, Sqlite, MySQL, PgSQL and Memcached...
 * Available as a **[Composer](http://https://packagist.org/packages/apix/cache)** and as a **[PEAR](http://pear.ouarz.net)** package.
 
 ---


### PR DESCRIPTION
I added PHP7 for the tests on travis-ci and changed the Readme file.

Additionally I changed these:
- I renamed DB=memcache to DB=memcached because memcached is tested
- I moved 2 lines to send the test result to scutinizer into the `after_script` section because this is not a part of the test itself