### PR TITLE
Fix fatal error on HHVM  due to `Memcached::deleteMulti()` being undefined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ install:
 before_script:
   # xdebug is not installed on HHVM and PHP 7, so skip code coverage (COVERAGE="no").
   - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then COVERAGE="no";  fi
-  - if [[ "$TRAVIS_PHP_VERSION" = "hhvm" ]]; then sudo /etc/init.d/memcached stop; fi
 
 script:
   - if [ "$COVERAGE" != "no" ]; then vendor/bin/phpunit --colors --verbose --coverage-text --coverage-clover build/logs/clover.xml; fi

--- a/tests/MemcachedTest.php
+++ b/tests/MemcachedTest.php
@@ -20,7 +20,11 @@ class MemcachedTest extends GenericTestCase
     const PORT = 11211;
     const AUTH = null;
 
-    protected $cache, $memcached;
+    /** @var \Apix\Cache\AbstractCache */
+    protected $cache;
+
+    /** @var \Memcached */
+    protected $memcached;
 
     protected $options = array(
         'prefix_key' => 'key_',


### PR DESCRIPTION
I fixed a fatel error when calling the `deleteMulti` function of Memcached on HHVM. Then this function is not available, the `delete` function is called instead for each entry.

I also removed the `sudo` command line from the .travis.yml, because the command is failing because `sudo` is disabled (`sudo: false` in .travis.yml) and memcached will work on HHVM now.

Additional to that I added some docblocks for better Code completion.