### PR TITLE
win eol handling in Files cache implementation

### DIFF
--- a/src/Files.php
+++ b/src/Files.php
@@ -60,13 +60,19 @@ class Files extends AbstractCache
             return null;
         }
         $pos = strpos($data, PHP_EOL, 0);
-        $pos = strpos($data, PHP_EOL, $pos+1);
         if (false === $pos) {// Un-complete file
             unlink($path);
             return null;
         }
 
-        $serialized = substr($data, $pos+1);
+        $eolLen = strlen(PHP_EOL);
+        $pos = strpos($data, PHP_EOL, $pos+$eolLen);
+        if (false === $pos) {// Un-complete file
+            unlink($path);
+            return null;
+        }
+
+        $serialized = substr($data, $pos+$eolLen);
         return unserialize($serialized);
     }
 


### PR DESCRIPTION
Hi Franck,

as discussed, PR opened for fixing issue on Files cache on Windows platform.
Unit tests in FilesTest.php (actually the ones inherited from GenericTestCases.php) were failing because of this specific issue. I didn't need to add some more to cover it. I just verified that the tests were running fine once fix is in place.