### PR TITLE
File and Directory Adapters @clean returns when fails to find a key within a tag

### DIFF
--- a/src/Directory.php
+++ b/src/Directory.php
@@ -371,7 +371,7 @@ class Directory extends AbstractCache
             $ids = $this->loadTag($tag);
 
             if (null === $ids) {
-                return false;
+                continue;
             }
             foreach ($ids as $key) {
                 $this->delete($this->removePrefixKey($key));

--- a/src/Directory.php
+++ b/src/Directory.php
@@ -367,19 +367,22 @@ class Directory extends AbstractCache
      */
     public function clean(array $tags)
     {
+        $cleaned = false;
         foreach ($tags as $tag) {
             $ids = $this->loadTag($tag);
 
             if (null === $ids) {
                 continue;
             }
+            $cleaned = true;
+
             foreach ($ids as $key) {
                 $this->delete($this->removePrefixKey($key));
             }
             unlink($this->getTagPath($this->mapTag($tag)));
         }
 
-        return true;
+        return $cleaned;
     }
 
     /**

--- a/src/Files.php
+++ b/src/Files.php
@@ -200,8 +200,8 @@ class Files extends AbstractCache
     public function clean(array $tags)
     {
         $toRemove = array();
-        $cleaned = true;
-        
+        $cleaned = false;
+
         foreach ($tags as $tag) {
             $keys = $this->loadTag($tag);
             if (null === $keys) {
@@ -216,7 +216,7 @@ class Files extends AbstractCache
             $this->delete($this->removePrefixKey($key));
         }
 
-        return true;
+        return $cleaned;
     }
 
     /**

--- a/src/Files.php
+++ b/src/Files.php
@@ -200,11 +200,14 @@ class Files extends AbstractCache
     public function clean(array $tags)
     {
         $toRemove = array();
+        $cleaned = true;
+        
         foreach ($tags as $tag) {
             $keys = $this->loadTag($tag);
             if (null === $keys) {
-                return false;
+                continue;
             }
+            $cleaned = true;
             $toRemove = array_merge($toRemove, $keys);
         }
         $toRemove = array_unique($toRemove);


### PR DESCRIPTION
Directory adapter to continue trying to clean all tags instead of returning on the first miss