### PR TITLE
Fix `Files::clean` and `Directory::clean` return to early if failing to find a tag -- with supporting tests

### DIFF
--- a/src/Directory.php
+++ b/src/Directory.php
@@ -371,7 +371,7 @@ class Directory extends AbstractCache
             $ids = $this->loadTag($tag);
 
             if (null === $ids) {
-                return false;
+                continue;
             }
             foreach ($ids as $key) {
                 $this->delete($this->removePrefixKey($key));

--- a/src/Directory.php
+++ b/src/Directory.php
@@ -367,19 +367,22 @@ class Directory extends AbstractCache
      */
     public function clean(array $tags)
     {
+        $cleaned = false;
         foreach ($tags as $tag) {
             $ids = $this->loadTag($tag);
 
             if (null === $ids) {
                 continue;
             }
+            $cleaned = true;
+
             foreach ($ids as $key) {
                 $this->delete($this->removePrefixKey($key));
             }
             unlink($this->getTagPath($this->mapTag($tag)));
         }
 
-        return true;
+        return $cleaned;
     }
 
     /**

--- a/src/Files.php
+++ b/src/Files.php
@@ -200,8 +200,8 @@ class Files extends AbstractCache
     public function clean(array $tags)
     {
         $toRemove = array();
-        $cleaned = true;
-        
+        $cleaned = false;
+
         foreach ($tags as $tag) {
             $keys = $this->loadTag($tag);
             if (null === $keys) {
@@ -216,7 +216,7 @@ class Files extends AbstractCache
             $this->delete($this->removePrefixKey($key));
         }
 
-        return true;
+        return $cleaned;
     }
 
     /**

--- a/src/Files.php
+++ b/src/Files.php
@@ -200,11 +200,14 @@ class Files extends AbstractCache
     public function clean(array $tags)
     {
         $toRemove = array();
+        $cleaned = true;
+        
         foreach ($tags as $tag) {
             $keys = $this->loadTag($tag);
             if (null === $keys) {
-                return false;
+                continue;
             }
+            $cleaned = true;
             $toRemove = array_merge($toRemove, $keys);
         }
         $toRemove = array_unique($toRemove);

--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -55,4 +55,26 @@ class DirectoryTest extends GenericTestCase
         $this->assertTrue($this->cache->save('data', 'id', array('tag')));
         $this->assertTrue($this->cache->delete('id'));
     }
+
+    /**
+     * Regression test for pull request GH#17
+     *
+     * @link https://github.com/frqnck/apix-cache/pull/17/files
+     *       "File and Directory Adapters @clean returns when fails to find a
+     *        key within a tag"
+     * @see FilesTest\testPullRequest17()
+     * @group pr
+     */
+    public function testPullRequest17()
+    {
+        $this->cache->save('data1', 'id1', array('tag1', 'tag2'));
+
+        $this->assertNotNull($this->cache->loadTag('tag2'));
+        $this->assertTrue($this->cache->clean(array('non-existant', 'tag2')));
+        $this->assertNull($this->cache->loadTag('tag2'));
+
+        // for good measure.
+        $this->assertFalse($this->cache->clean(array('tag2')));
+    }
+
 }

--- a/tests/FilesTest.php
+++ b/tests/FilesTest.php
@@ -58,4 +58,26 @@ class FilesTest extends GenericTestCase
         file_put_contents($this->cache->getOption('directory').DIRECTORY_SEPARATOR.$encoded, PHP_EOL);
         $this->assertNull($this->cache->loadKey('id'));
     }
+
+    /**
+     * Regression test for pull request GH#17
+     *
+     * @link https://github.com/frqnck/apix-cache/pull/17/files
+     *       "File and Directory Adapters @clean returns when fails to find a
+     *        key within a tag"
+     * @see DirectoryTest\testPullRequest17()
+     * @group pr
+     */
+    public function testPullRequest17()
+    {
+        $this->cache->save('data1', 'id1', array('tag1', 'tag2'));
+
+        $this->assertNotNull($this->cache->loadTag('tag2'));
+        $this->assertTrue($this->cache->clean(array('non-existant', 'tag2')));
+        $this->assertNull($this->cache->loadTag('tag2'));
+
+        // for good measure.
+        $this->assertFalse($this->cache->clean(array('tag2')));
+    }
+
 }


### PR DESCRIPTION
## What did you implement:

**Implementing tests** for PR#17

## How can we verify it:

` $ phpunit --group pr`
## Done and todos:

<!-- Please tick with [x] as appropriate. -->

- [x] Write unit tests,
- [ ] Write documentation,
- [ ] Fix linting errors,
- [x] Make sure code coverage hasn't dropped,
- [x] Leave a comment that this is ready for review once you've finished the implementation.