### PR TITLE
Fix deprecated setExpiration method

### DIFF
--- a/src/PsrCache/Item.php
+++ b/src/PsrCache/Item.php
@@ -131,7 +131,7 @@ class Item implements ItemInterface
      */
     public function setExpiration($ttl = null)
     {
-        if (is_int($expiration)) {
+        if (is_int($ttl)) {
             $ttl = new \DateTime('now +' . $ttl . ' seconds');
         }
 


### PR DESCRIPTION
The setExpiration method uses a $ttl param but $expiration was used instead.