### PR TITLE
Fix AbstractPdo::flush() to match Adapter::flush documentation

### DIFF
--- a/src/AbstractPdo.php
+++ b/src/AbstractPdo.php
@@ -84,7 +84,14 @@ abstract class AbstractPdo extends AbstractCache
         if (!isset($this->sql_definitions[$index])) {
             return false;
         }
-        $this->adapter->exec($this->getSql($index, $this->options['db_table']));
+
+        try {
+            $this->adapter->exec($this->getSql($index, $this->options['db_table']));
+        } catch (\PDOException $ex) {
+            if (1061 !== $ex->errorInfo[1]) {
+                // if not "Index already exists"
+            }
+        }
 
         return $this->adapter->errorCode() == '00000';
     }
@@ -201,11 +208,12 @@ abstract class AbstractPdo extends AbstractCache
             return false !== $this->adapter->exec($this->getSql('flush_all'));
         }
 
-        $value = implode(' OR ', array(
-            'key like \''.$this->options['prefix_key'].'%\'',
-            'tags like \''.$this->options['prefix_tag'].'%\''));
+        $value = array(
+            $this->options['prefix_key'].'%',
+            $this->options['prefix_tag'].'%'
+        );
 
-        return (boolean) $this->adapter->exec($this->getSql('flush', $value));
+        return (boolean) $this->exec($this->getSql('flush'), $value)->rowCount();
     }
 
     /**

--- a/src/AbstractPdo.php
+++ b/src/AbstractPdo.php
@@ -201,7 +201,11 @@ abstract class AbstractPdo extends AbstractCache
             return false !== $this->adapter->exec($this->getSql('flush_all'));
         }
 
-        return (boolean) $this->adapter->exec($this->getSql('flush'));
+        $value = implode(' OR ', array(
+            'key like \''.$this->options['prefix_key'].'%\'',
+            'tags like \''.$this->options['prefix_tag'].'%\''));
+
+        return (boolean) $this->adapter->exec($this->getSql('flush', $value));
     }
 
     /**

--- a/src/Pdo/Mysql.php
+++ b/src/Pdo/Mysql.php
@@ -50,8 +50,8 @@ class Mysql extends AbstractPdo
         'delete'    => 'DELETE FROM `%s` WHERE `key`=?;',
         'clean'     => 'DELETE FROM `%s` WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DROP TABLE IF EXISTS `%s`;',
-        'flush'     => 'DELETE FROM `%s`;',
+        'flush_all' => 'DELETE FROM `%s`;',
+        'flush'     => 'DELETE FROM `%s` WHERE %s;',
         'purge'     => 'DELETE FROM `%s` WHERE `expire` IS NOT NULL AND `expire` < %d;'
     );
 

--- a/src/Pdo/Mysql.php
+++ b/src/Pdo/Mysql.php
@@ -51,7 +51,7 @@ class Mysql extends AbstractPdo
         'clean'     => 'DELETE FROM `%s` WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
         'flush_all' => 'DELETE FROM `%s`;',
-        'flush'     => 'DELETE FROM `%s` WHERE %s;',
+        'flush'     => 'DELETE FROM `%s` WHERE `key` LIKE ? OR `tags` LIKE ?;',
         'purge'     => 'DELETE FROM `%s` WHERE `expire` IS NOT NULL AND `expire` < %d;'
     );
 

--- a/src/Pdo/Pgsql.php
+++ b/src/Pdo/Pgsql.php
@@ -43,8 +43,8 @@ class Pgsql extends AbstractPdo
         'delete'    => 'DELETE FROM "%s" WHERE "key"=?;',
         'clean'     => 'DELETE FROM "%s" WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DROP TABLE IF EXISTS "%s";',
-        'flush'     => 'DELETE FROM "%s";',
+        'flush_all' => 'DELETE FROM `%s`;',
+        'flush'     => 'DELETE FROM `%s` WHERE %s;',
         'purge'     => 'DELETE FROM "%s" WHERE "expire" IS NOT NULL AND "expire" < %d;'
     );
 

--- a/src/Pdo/Pgsql.php
+++ b/src/Pdo/Pgsql.php
@@ -44,7 +44,7 @@ class Pgsql extends AbstractPdo
         'clean'     => 'DELETE FROM "%s" WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
         'flush_all' => 'DELETE FROM "%s";',
-        'flush'     => 'DELETE FROM "%s" WHERE %s;',
+        'flush'     => 'DELETE FROM "%s" WHERE "key" LIKE ? OR "tags" LIKE ?;',
         'purge'     => 'DELETE FROM "%s" WHERE "expire" IS NOT NULL AND "expire" < %d;'
     );
 

--- a/src/Pdo/Pgsql.php
+++ b/src/Pdo/Pgsql.php
@@ -43,8 +43,8 @@ class Pgsql extends AbstractPdo
         'delete'    => 'DELETE FROM "%s" WHERE "key"=?;',
         'clean'     => 'DELETE FROM "%s" WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DELETE FROM `%s`;',
-        'flush'     => 'DELETE FROM `%s` WHERE %s;',
+        'flush_all' => 'DELETE FROM "%s";',
+        'flush'     => 'DELETE FROM "%s" WHERE %s;',
         'purge'     => 'DELETE FROM "%s" WHERE "expire" IS NOT NULL AND "expire" < %d;'
     );
 

--- a/src/Pdo/Sql1999.php
+++ b/src/Pdo/Sql1999.php
@@ -49,8 +49,8 @@ class Sql1999 extends AbstractPdo
         'delete'    => 'DELETE FROM "%s" WHERE "key"=?;',
         'clean'     => 'DELETE FROM "%s" WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DELETE FROM `%s`;',
-        'flush'     => 'DELETE FROM `%s` WHERE %s;',
+        'flush_all' => 'DELETE FROM "%s";',
+        'flush'     => 'DELETE FROM "%s" WHERE %s;',
         'purge'     => 'DELETE FROM "%s" WHERE "expire" IS NOT NULL AND "expire" < %d;'
     );
 

--- a/src/Pdo/Sql1999.php
+++ b/src/Pdo/Sql1999.php
@@ -49,8 +49,8 @@ class Sql1999 extends AbstractPdo
         'delete'    => 'DELETE FROM "%s" WHERE "key"=?;',
         'clean'     => 'DELETE FROM "%s" WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DROP TABLE IF EXISTS "%s";',
-        'flush'     => 'DELETE FROM "%s";',
+        'flush_all' => 'DELETE FROM `%s`;',
+        'flush'     => 'DELETE FROM `%s` WHERE %s;',
         'purge'     => 'DELETE FROM "%s" WHERE "expire" IS NOT NULL AND "expire" < %d;'
     );
 

--- a/src/Pdo/Sql1999.php
+++ b/src/Pdo/Sql1999.php
@@ -50,7 +50,7 @@ class Sql1999 extends AbstractPdo
         'clean'     => 'DELETE FROM "%s" WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
         'flush_all' => 'DELETE FROM "%s";',
-        'flush'     => 'DELETE FROM "%s" WHERE %s;',
+        'flush'     => 'DELETE FROM %s WHERE key LIKE ? OR tags LIKE ?;',
         'purge'     => 'DELETE FROM "%s" WHERE "expire" IS NOT NULL AND "expire" < %d;'
     );
 

--- a/src/Pdo/Sqlite.php
+++ b/src/Pdo/Sqlite.php
@@ -42,8 +42,8 @@ class Sqlite extends AbstractPdo
         'delete'    => 'DELETE FROM %s WHERE key = ?;',
         'clean'     => 'DELETE FROM %s WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DROP TABLE IF EXISTS %s;',
-        'flush'     => 'DELETE FROM %s;',
+        'flush_all' => 'DELETE FROM `%s`;',
+        'flush'     => 'DELETE FROM `%s` WHERE %s;',
         'purge'     => 'DELETE FROM %s WHERE expire IS NOT NULL AND expire < %d;'
     );
 

--- a/src/Pdo/Sqlite.php
+++ b/src/Pdo/Sqlite.php
@@ -42,8 +42,8 @@ class Sqlite extends AbstractPdo
         'delete'    => 'DELETE FROM %s WHERE key = ?;',
         'clean'     => 'DELETE FROM %s WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
-        'flush_all' => 'DELETE FROM `%s`;',
-        'flush'     => 'DELETE FROM `%s` WHERE %s;',
+        'flush_all' => 'DELETE FROM %s;',
+        'flush'     => 'DELETE FROM %s WHERE %s;',
         'purge'     => 'DELETE FROM %s WHERE expire IS NOT NULL AND expire < %d;'
     );
 

--- a/src/Pdo/Sqlite.php
+++ b/src/Pdo/Sqlite.php
@@ -43,7 +43,7 @@ class Sqlite extends AbstractPdo
         'clean'     => 'DELETE FROM %s WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',
         'flush_all' => 'DELETE FROM %s;',
-        'flush'     => 'DELETE FROM %s WHERE %s;',
+        'flush'     => 'DELETE FROM %s WHERE key LIKE ? OR tags LIKE ?;',
         'purge'     => 'DELETE FROM %s WHERE expire IS NOT NULL AND expire < %d;'
     );
 

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -133,7 +133,7 @@ class PdoTest extends GenericTestCase
     }
 
     /**
-     * @expectedException PDOException
+     *
      */
     public function testFlushAll()
     {


### PR DESCRIPTION
Either delete all of the rows in the cache table or only the rows
that start with the key prefix or the tag prefix.

The previous implementation would drop the cache table which would
result in an exception if flush(true) was called and the cache
were subsequently read.

<!--
1. Please check the Contributing Guidelines: https://github.com/frqnck/apix-cache/blob/master/.github/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
-->

## What did you implement:

**Implementing Issue:** #40 

<!-- Briefly describe the feature if no issue exists for this PR. -->

## How did you implement it:
Changed the AbstractPdo::flush() method to behave how the documentation for Adapter::flush() says it should. If $all is true then delete the entire table. If $all is false, only delete rows that have a key with the prefix or tags with the prefix.

## How can we verify it:

<!-- Please provide any applicable commands or other resources to make it easy for us to verify this works. -->

## Done and todos:

<!-- Please tick with [x] as appropriate. -->

- [x ] Write unit tests,
- [ ] Write documentation,
- [ ] Fix linting errors,
- [ x] Make sure code coverage hasn't dropped,
- [ x] Leave a comment that this is ready for review once you've finished the implementation.
